### PR TITLE
Adjusting the missing move numbers for livechesscloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,166 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+
+# PyCache
+./lib/__pycache__
+./lib/__pycache__/*
+__pycache__

--- a/lib/bp_livechesscloud.py
+++ b/lib/bp_livechesscloud.py
@@ -15,20 +15,20 @@ from lib.bp_interface import InternetGameInterface
 class InternetGameLivechesscloud(InternetGameInterface):
     def __init__(self):
         InternetGameInterface.__init__(self)
-        self.regexes.update({'id': re.compile(r'^[0-9a-f-]{36}$', re.IGNORECASE)})
+        self.regexes.update({"id": re.compile(r"^[0-9a-f-]{36}$", re.IGNORECASE)})
 
     def get_identity(self) -> Tuple[str, int, int]:
-        return 'LiveChessCloud.com', BOARD_CHESS, METHOD_API
+        return "LiveChessCloud.com", BOARD_CHESS, METHOD_API
 
     def assign_game(self, url: str) -> bool:
         # Verify the hostname
         parsed = urlparse(url)
-        if parsed.netloc.lower() != 'view.livechesscloud.com':
+        if parsed.netloc.lower() != "view.livechesscloud.com":
             return False
 
         # Verify the identifier
         gid = parsed.path[1:] or parsed.fragment
-        if self.regexes['id'].match(gid) is not None:
+        if self.regexes["id"].match(gid) is not None:
             self.id = gid
             return True
         return False
@@ -39,74 +39,115 @@ class InternetGameLivechesscloud(InternetGameInterface):
             return None
 
         # Fetch the host
-        bourne = self.send_xhr('http://lookup.livechesscloud.com/meta/' + self.id, None)
+        bourne = self.send_xhr("http://lookup.livechesscloud.com/meta/" + self.id, None)
         data = self.json_loads(bourne)
-        host = self.json_field(data, 'host')
-        if host == '' or (self.json_field(data, 'format') != '1'):
+        host = self.json_field(data, "host")
+        if host == "" or (self.json_field(data, "format") != "1"):
             return None
 
         # Fetch the tournament
-        pgn = ''
-        bourne = self.send_xhr('http://%s/get/%s/tournament.json' % (host, self.id), None)
+        pgn = ""
+        bourne = self.send_xhr(
+            "http://%s/get/%s/tournament.json" % (host, self.id), None
+        )
         data = self.json_loads(bourne)
-        game = {'TimeControl': self.json_field(data, 'timecontrol').replace('"', '').replace("'", ''),
-                'Event': self.json_field(data, 'name'),
-                'Site': ('%s %s' % (self.json_field(data, 'country'), self.json_field(data, 'location'))).strip()}
-        variant = self.json_field(data, 'rules')
-        if variant != 'STANDARD':
-            game['Variant'] = variant
-        nb_rounds = len(self.json_field(data, 'rounds', []))
+        game = {
+            "TimeControl": self.json_field(data, "timecontrol")
+            .replace('"', "")
+            .replace("'", ""),
+            "Event": self.json_field(data, "name"),
+            "Site": (
+                "%s %s"
+                % (self.json_field(data, "country"), self.json_field(data, "location"))
+            ).strip(),
+        }
+        variant = self.json_field(data, "rules")
+        if variant != "STANDARD":
+            game["Variant"] = variant
+        nb_rounds = len(self.json_field(data, "rounds", []))
         if nb_rounds == 0:
             return None
 
         # Fetch the rounds
         for i in range(1, nb_rounds + 1):
-            bourne = self.send_xhr('http://%s/get/%s/round-%d/index.json' % (host, self.id, i), None)
+            bourne = self.send_xhr(
+                "http://%s/get/%s/round-%d/index.json" % (host, self.id, i), None
+            )
             data = self.json_loads(bourne)
-            game['Date'] = self.json_field(data, 'date')
-            pairings = self.json_field(data, 'pairings', [])
+            game["Date"] = self.json_field(data, "date")
+            pairings = self.json_field(data, "pairings", [])
             nb_pairings = len(pairings)
             if nb_pairings > 0:
                 for j in range(nb_pairings):
                     # Players and result
-                    player = pairings[j].get('white', {})
-                    game['White'] = ('%s %s' % (self.json_field(player, 'lname'), self.json_field(player, 'fname'))).strip()
-                    player = pairings[j].get('black', {})
-                    game['Black'] = ('%s %s' % (self.json_field(player, 'lname'), self.json_field(player, 'fname'))).strip()
-                    game['Result'] = self.json_field(pairings[j], 'result', '*')
-                    game['Round'] = '%d.%d' % (i, j + 1)
+                    player = pairings[j].get("white", {})
+                    game["White"] = (
+                        "%s %s"
+                        % (
+                            self.json_field(player, "lname"),
+                            self.json_field(player, "fname"),
+                        )
+                    ).strip()
+                    player = pairings[j].get("black", {})
+                    game["Black"] = (
+                        "%s %s"
+                        % (
+                            self.json_field(player, "lname"),
+                            self.json_field(player, "fname"),
+                        )
+                    ).strip()
+                    game["Result"] = self.json_field(pairings[j], "result", "*")
+                    game["Round"] = "%d.%d" % (i, j + 1)
 
                     # Fetch the moves
-                    game['_moves'] = ''
-                    bourne2 = self.send_xhr('http://%s/get/%s/round-%d/game-%d.json?poll=' % (host, self.id, i, j + 1), None)
+                    game["_moves"] = ""
+                    bourne2 = self.send_xhr(
+                        "http://%s/get/%s/round-%d/game-%d.json?poll="
+                        % (host, self.id, i, j + 1),
+                        None,
+                    )
                     data2 = self.json_loads(bourne2)
-                    if self.json_field(data2, 'result') == 'NOTPLAYED':
+                    if self.json_field(data2, "result") == "NOTPLAYED":
                         continue
-                    fischer_id = self.json_field(data2, 'chess960', CHESS960_CLASSICAL)
+                    fischer_id = self.json_field(data2, "chess960", CHESS960_CLASSICAL)
                     if fischer_id == CHESS960_CLASSICAL:
-                        for k in ['Variant', 'SetUp', 'FEN']:
+                        for k in ["Variant", "SetUp", "FEN"]:
                             if k in game:
                                 del game[k]
                     else:
-                        game['Variant'] = CHESS960
-                        game['SetUp'] = '1'
-                        game['FEN'] = chess.Board.from_chess960_pos(fischer_id).fen()
-                    game['_reason'] = self.json_field(data2, 'comment')
-                    moves = self.json_field(data2, 'moves')
+                        game["Variant"] = CHESS960
+                        game["SetUp"] = "1"
+                        game["FEN"] = chess.Board.from_chess960_pos(fischer_id).fen()
+                    game["_reason"] = self.json_field(data2, "comment")
+                    moves = self.json_field(data2, "moves")
+
+                    move_number = 1
                     for move in moves:
-                        move = move.split(' ')[0]
-                        game['_moves'] += '%s ' % move
+                        move = move.split(" ")[0]
+                        if move_number % 2 == 1:
+                            game["_moves"] += f"{move_number // 2 + 1}.{move} "
+                        else:
+                            game["_moves"] += f"{move} "
+                        move_number += 1
 
                     # Game
                     candidate = self.rebuild_pgn(game)
                     if candidate is not None:
-                        pgn += candidate.strip() + '\n\n'
+                        pgn += candidate.strip() + "\n\n"
 
         # Return the games
         return pgn
 
     def get_test_links(self) -> List[Tuple[str, bool]]:
-        return [('https://view.livechesscloud.com/30d54b79-e852-4788-bb91-403955efd6a3', True),     # Games
-                ('https://view.livechesscloud.com/#30d54b79-e852-4788-bb91-403955efd6a3', True),    # Games, other scheme
-                # No example found for Chess960
-                ('http://view.livechesscloud.com', False)]                                          # Not a game (homepage)
+        return [
+            (
+                "https://view.livechesscloud.com/30d54b79-e852-4788-bb91-403955efd6a3",
+                True,
+            ),  # Games
+            (
+                "https://view.livechesscloud.com/#30d54b79-e852-4788-bb91-403955efd6a3",
+                True,
+            ),  # Games, other scheme
+            # No example found for Chess960
+            ("http://view.livechesscloud.com", False),
+        ]  # Not a game (homepage)


### PR DESCRIPTION
Fix: #3 

The train numbers are now displayed and output in the typical PGN format. 

Example:
```bash
 python boards.py download https://view.livechesscloud.com/#1eb49a34-ddb6-436a-b1bf-f4fc03c488d1
```

-> (now)

```bash
[Event "20. Bad Koenigshofen Open 2023"]
[Site "DE Bad Koenigshofen"]
[Date "2023-12-30"]
[Round "7.26"]
[White "Sereda Polina"]
[Black "Schönrock Rüdiger"]
[Result "*"]
[TimeControl "Fischer Short"]

1.e4 e5 2.Nf3 Nf6 3.Nxe5 d6 4.Nf3 Nxe4 5.Qe2 Qe7 6.d3 Nc5 7.Be3 Bg4 8.Nc3 c6 9.d4 Ne4 10.Qd3 Nxc3 11.Qxc3 Nd7 12.Be2 Nf6 13.Bg5 O-O-O 14.Be3 Nd5 15.Qa3 Re8 16.O-O Nxe3 17.fxe3 Qxe3+ 18.Qxe3 Rxe3 19.Rae1 Re7 20.h3 Bxf3 21.Rxf3 g6 22.Kf1 Bg7 23.c3 Rhe8 24.Rf2 Bh6 25.Bg4+ f5 26.Rxe7 Rxe7 27.Bd1 Kc7 28.Bf3 d5 29.Rc2 Kd6 30.Kf2 b5 31.b3 b4 32.cxb4 Be3+ 33.Kf1 Bxd4 34.Be2 Rb7 35.a3 Re7 36.Bd1 Re3 37.Ra2 Bc3 38.Kf2 f4 39.Re2 Rxe2+ 40.Bxe2 Bb2 41.a4 Bc3 42.b5 cxb5 43.Bxb5 Kc5 44.Kf3 g5 45.Kg4 Bd2 46.g3 fxg3 47.Kxg3 Kb4 48.Bc6 Kxb3 49.Bxd5+ Kxa4 *
```

